### PR TITLE
Fix mistake on buffer size of dynamic array.

### DIFF
--- a/pawn/scripting/include/smjansson.inc
+++ b/pawn/scripting/include/smjansson.inc
@@ -871,7 +871,7 @@ stock Handle json_string_format(const char[] sFormat, any ...) {
  */
 stock Handle json_string_format_ex(int tmpBufferLength, const char[] sFormat, any ...) {
 	char[] sTmp = new char[tmpBufferLength];
-	VFormat(sTmp, sTmp, sFormat, 3);
+	VFormat(sTmp, tmpBufferLength, sFormat, 3);
 
 	return json_string(sTmp);
 }


### PR DESCRIPTION
I think I zoned out super hard on the last commit that introduced this problem. Don't even remember making the PR.

This PR fixes the buffer size param for the dynamic array.